### PR TITLE
Refactor introduce JwtAuthenticationFilterPort for better abstraction

### DIFF
--- a/src/main/java/com/codesumn/accounts_payables_system_springboot/application/config/SecurityConfig.java
+++ b/src/main/java/com/codesumn/accounts_payables_system_springboot/application/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 package com.codesumn.accounts_payables_system_springboot.application.config;
 
-import com.codesumn.accounts_payables_system_springboot.application.filters.JwtAuthenticationFilter;
+import com.codesumn.accounts_payables_system_springboot.domain.inbound.JwtAuthenticationFilterPort;
 import com.codesumn.accounts_payables_system_springboot.shared.exceptions.handlers.CustomAccessDeniedHandler;
 import com.codesumn.accounts_payables_system_springboot.shared.exceptions.handlers.CustomAuthenticationHandler;
 import org.springframework.context.annotation.Bean;
@@ -21,16 +21,16 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity
 public class SecurityConfig {
 
-    private final JwtAuthenticationFilter jwtAuthFilter;
+    private final JwtAuthenticationFilterPort jwtFilterPort;
     private final CustomAccessDeniedHandler accessDeniedHandler;
     private final CustomAuthenticationHandler authenticationEntryPoint;
 
     public SecurityConfig(
-            JwtAuthenticationFilter jwtAuthFilter,
+            JwtAuthenticationFilterPort jwtFilterPort,
             CustomAccessDeniedHandler accessDeniedHandler,
             CustomAuthenticationHandler authenticationEntryPoint
     ) {
-        this.jwtAuthFilter = jwtAuthFilter;
+        this.jwtFilterPort = jwtFilterPort;
         this.accessDeniedHandler = accessDeniedHandler;
         this.authenticationEntryPoint = authenticationEntryPoint;
     }
@@ -49,7 +49,7 @@ public class SecurityConfig {
                         .authenticationEntryPoint(authenticationEntryPoint))
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtFilterPort.getFilter(), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/codesumn/accounts_payables_system_springboot/domain/inbound/JwtAuthenticationFilterPort.java
+++ b/src/main/java/com/codesumn/accounts_payables_system_springboot/domain/inbound/JwtAuthenticationFilterPort.java
@@ -1,0 +1,7 @@
+package com.codesumn.accounts_payables_system_springboot.domain.inbound;
+
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public interface JwtAuthenticationFilterPort {
+    OncePerRequestFilter getFilter();
+}

--- a/src/main/java/com/codesumn/accounts_payables_system_springboot/infrastructure/adapters/inbound/filters/JwtAuthenticationFilterAdapter.java
+++ b/src/main/java/com/codesumn/accounts_payables_system_springboot/infrastructure/adapters/inbound/filters/JwtAuthenticationFilterAdapter.java
@@ -1,9 +1,10 @@
-package com.codesumn.accounts_payables_system_springboot.application.filters;
+package com.codesumn.accounts_payables_system_springboot.infrastructure.adapters.inbound.filters;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.codesumn.accounts_payables_system_springboot.application.config.EnvironConfig;
+import com.codesumn.accounts_payables_system_springboot.domain.inbound.JwtAuthenticationFilterPort;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -20,13 +21,18 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 
 @Component
-public class JwtAuthenticationFilter extends OncePerRequestFilter {
+public class JwtAuthenticationFilterAdapter extends OncePerRequestFilter implements JwtAuthenticationFilterPort {
 
     private final UserDetailsService userDetailsService;
     private final String jwtSecret = EnvironConfig.JWT_SECRET;
 
-    public JwtAuthenticationFilter(UserDetailsService userDetailsService) {
+    public JwtAuthenticationFilterAdapter(UserDetailsService userDetailsService) {
         this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    public OncePerRequestFilter getFilter() {
+        return this;
     }
 
     @Override


### PR DESCRIPTION
- Create `JwtAuthenticationFilterPort` interface to decouple filter logic.
- Update `SecurityConfig` to use `JwtAuthenticationFilterPort` instead of the concrete `JwtAuthenticationFilter`.
- Rename and relocate `JwtAuthenticationFilter` to `JwtAuthenticationFilterAdapter` under `infrastructure/adapters/inbound/filters`.
- Implement `JwtAuthenticationFilterPort` in `JwtAuthenticationFilterAdapter` to align with new architecture.