### PR TITLE
Add comprehensive unit tests for application services

### DIFF
--- a/src/test/java/com/codesumn/accounts_payables_system_springboot/application/adapters/inbound/AccountItemWriterTest.java
+++ b/src/test/java/com/codesumn/accounts_payables_system_springboot/application/adapters/inbound/AccountItemWriterTest.java
@@ -1,0 +1,112 @@
+package com.codesumn.accounts_payables_system_springboot.application.adapters.inbound;
+
+import com.codesumn.accounts_payables_system_springboot.domain.models.AccountModel;
+import com.codesumn.accounts_payables_system_springboot.domain.outbound.AccountPersistencePort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ExecutionContext;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class AccountItemWriterTest {
+
+    @Mock
+    private AccountPersistencePort accountPersistencePort;
+
+    @Mock
+    private StepExecution stepExecution;
+
+    @InjectMocks
+    private AccountItemWriter accountItemWriter;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void beforeStep_shouldResetSavedCount() {
+
+        JobExecution mockJobExecution = mock(JobExecution.class);
+        ExecutionContext mockExecutionContext = new ExecutionContext();
+
+        when(stepExecution.getJobExecution()).thenReturn(mockJobExecution);
+        when(mockJobExecution.getExecutionContext()).thenReturn(mockExecutionContext);
+
+        accountItemWriter.beforeStep(stepExecution);
+        ExitStatus exitStatus = accountItemWriter.afterStep(stepExecution);
+
+        assert exitStatus != null;
+        assertThat(exitStatus.getExitCode()).isEqualTo(ExitStatus.COMPLETED.getExitCode());
+        assertThat(mockExecutionContext.getInt("importedCount", -1)).isEqualTo(0);
+    }
+
+    @Test
+    void write_shouldSaveAccountsAndIncrementSavedCount() {
+
+        AccountModel account1 = new AccountModel();
+        account1.setId(UUID.randomUUID());
+        account1.setAmount(BigDecimal.valueOf(100));
+        account1.setDescription("Account 1");
+
+        AccountModel account2 = new AccountModel();
+        account2.setId(UUID.randomUUID());
+        account2.setAmount(BigDecimal.valueOf(200));
+        account2.setDescription("Account 2");
+
+        List<AccountModel> accounts = Arrays.asList(account1, account2);
+        Chunk<AccountModel> chunk = new Chunk<>(accounts);
+
+        accountItemWriter.write(chunk);
+
+        ArgumentCaptor<AccountModel> captor = ArgumentCaptor.forClass(AccountModel.class);
+        verify(accountPersistencePort, times(2)).saveAccount(captor.capture());
+
+        List<AccountModel> capturedAccounts = captor.getAllValues();
+        assertThat(capturedAccounts).containsExactly(account1, account2);
+    }
+
+    @Test
+    void afterStep_shouldSetImportedCountInExecutionContext() {
+
+        AccountModel account1 = new AccountModel();
+        account1.setId(UUID.randomUUID());
+        account1.setAmount(BigDecimal.valueOf(100));
+        account1.setDescription("Account 1");
+
+        AccountModel account2 = new AccountModel();
+        account2.setId(UUID.randomUUID());
+        account2.setAmount(BigDecimal.valueOf(200));
+        account2.setDescription("Account 2");
+
+        List<AccountModel> accounts = Arrays.asList(account1, account2);
+        Chunk<AccountModel> chunk = new Chunk<>(accounts);
+
+        accountItemWriter.beforeStep(stepExecution);
+        accountItemWriter.write(chunk);
+
+        JobExecution mockJobExecution = mock(JobExecution.class);
+        ExecutionContext mockExecutionContext = new ExecutionContext();
+        when(stepExecution.getJobExecution()).thenReturn(mockJobExecution);
+        when(mockJobExecution.getExecutionContext()).thenReturn(mockExecutionContext);
+
+        ExitStatus exitStatus = accountItemWriter.afterStep(stepExecution);
+
+        assertThat(exitStatus).isEqualTo(ExitStatus.COMPLETED);
+        assertThat(mockExecutionContext.getInt("importedCount")).isEqualTo(2);
+    }
+}

--- a/src/test/java/com/codesumn/accounts_payables_system_springboot/application/adapters/inbound/AccountServiceAdapterTest.java
+++ b/src/test/java/com/codesumn/accounts_payables_system_springboot/application/adapters/inbound/AccountServiceAdapterTest.java
@@ -1,0 +1,248 @@
+package com.codesumn.accounts_payables_system_springboot.application.adapters.inbound;
+
+import com.codesumn.accounts_payables_system_springboot.application.dtos.records.account.AccountInputRecordDto;
+import com.codesumn.accounts_payables_system_springboot.domain.models.AccountModel;
+import com.codesumn.accounts_payables_system_springboot.domain.outbound.AccountCsvImportPort;
+import com.codesumn.accounts_payables_system_springboot.domain.outbound.AccountPersistencePort;
+import com.codesumn.accounts_payables_system_springboot.shared.enums.AccountStatusEnum;
+import com.codesumn.accounts_payables_system_springboot.shared.exceptions.errors.ResourceNotFoundException;
+import com.codesumn.accounts_payables_system_springboot.shared.parsers.SortParser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.data.domain.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AccountServiceAdapterTest {
+
+    @Mock
+    private AccountPersistencePort accountPersistencePort;
+
+    @Mock
+    private SortParser sortParser;
+
+    @Mock
+    private AccountCsvImportPort accountCsvImportPort;
+
+    private AccountServiceAdapter accountServiceAdapter;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+
+        accountServiceAdapter = new AccountServiceAdapter(
+                accountPersistencePort,
+                sortParser,
+                accountCsvImportPort
+        );
+    }
+
+    @Test
+    void getAccountById_shouldReturnAccount_whenFound() {
+        UUID accountId = UUID.randomUUID();
+        AccountModel model = new AccountModel();
+        model.setId(accountId);
+        model.setStatus(AccountStatusEnum.PENDING);
+
+        when(accountPersistencePort.findById(accountId))
+                .thenReturn(Optional.of(model));
+
+        var response = accountServiceAdapter.getAccountById(accountId);
+
+        assertThat(response.data().status()).isEqualTo(AccountStatusEnum.PENDING);
+        assertThat(response.data().id()).isEqualTo(accountId);
+
+        verify(accountPersistencePort).findById(accountId);
+        verifyNoMoreInteractions(accountPersistencePort);
+    }
+
+    @Test
+    void getAccountById_shouldThrow_whenNotFound() {
+        UUID accountId = UUID.randomUUID();
+        when(accountPersistencePort.findById(accountId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> accountServiceAdapter.getAccountById(accountId))
+                .isInstanceOf(ResourceNotFoundException.class);
+
+        verify(accountPersistencePort).findById(accountId);
+    }
+
+    @Test
+    void createAccount_shouldSaveAndReturnCreatedAccount() {
+        LocalDate ld = LocalDate.of(2023, 1, 10);
+        Date date = localDateToDate(ld);
+
+        AccountInputRecordDto dto = new AccountInputRecordDto(
+                date,
+                date,
+                new BigDecimal("1000.00"),
+                "Test Create",
+                AccountStatusEnum.PENDING
+        );
+
+        AccountModel savedModel = new AccountModel();
+        savedModel.setId(UUID.randomUUID());
+        savedModel.setDueDate(dto.dueDate());
+        savedModel.setPaymentDate(dto.paymentDate());
+        savedModel.setAmount(dto.amount());
+        savedModel.setDescription(dto.description());
+        savedModel.setStatus(dto.status());
+
+        when(accountPersistencePort.saveAccount(any(AccountModel.class)))
+                .thenReturn(savedModel);
+
+        var result = accountServiceAdapter.createAccount(dto);
+
+        assertThat(result.data().id()).isNull();
+        assertThat(result.data().description()).isEqualTo("Test Create");
+        verify(accountPersistencePort).saveAccount(any(AccountModel.class));
+    }
+
+    @Test
+    void updateAccount_shouldUpdateAndReturn() {
+        LocalDate ld = LocalDate.of(2023, 1, 10);
+        Date date = localDateToDate(ld);
+
+        UUID existingId = UUID.randomUUID();
+
+        AccountModel existingModel = new AccountModel();
+        existingModel.setId(existingId);
+        existingModel.setDescription("Old Description");
+
+        when(accountPersistencePort.findById(existingId))
+                .thenReturn(Optional.of(existingModel));
+
+        AccountInputRecordDto dto = new AccountInputRecordDto(
+                date,
+                date,
+                new BigDecimal("555.55"),
+                "New Desc",
+                AccountStatusEnum.PAID
+        );
+
+        AccountModel updatedModel = new AccountModel();
+        updatedModel.setId(existingId);
+        updatedModel.setDescription("New Desc");
+        updatedModel.setStatus(AccountStatusEnum.PAID);
+
+        when(accountPersistencePort.saveAccount(any(AccountModel.class)))
+                .thenReturn(updatedModel);
+
+        var response = accountServiceAdapter.updateAccount(existingId, dto);
+
+        assertThat(response.data().id()).isEqualTo(existingId);
+        assertThat(response.data().description()).isEqualTo("New Desc");
+        assertThat(response.data().status()).isEqualTo(AccountStatusEnum.PAID);
+
+        verify(accountPersistencePort).findById(existingId);
+        verify(accountPersistencePort).saveAccount(any(AccountModel.class));
+    }
+
+    @Test
+    void getAll_shouldReturnPaginationResponse() throws IOException {
+        int page = 1;
+        int pageSize = 2;
+        String searchTerm = "test";
+        String sorting = "someSortingJSON";
+
+        when(sortParser.parseSorting(sorting)).thenReturn(Sort.by("dueDate"));
+
+        AccountModel m1 = new AccountModel();
+        m1.setId(UUID.randomUUID());
+        m1.setDescription("Desc1");
+
+        AccountModel m2 = new AccountModel();
+        m2.setId(UUID.randomUUID());
+        m2.setDescription("Desc2");
+
+        Page<AccountModel> mockedPage = new PageImpl<>(
+                List.of(m1, m2),
+                PageRequest.of(0, pageSize, Sort.by("dueDate")),
+                2
+        );
+
+        when(accountPersistencePort.findAll(eq(searchTerm), any(Pageable.class)))
+                .thenReturn(mockedPage);
+
+        var result = accountServiceAdapter.getAll(page, pageSize, searchTerm, sorting);
+
+        assertThat(result.data()).hasSize(2);
+        assertThat(result.data().get(0).description()).isEqualTo("Desc1");
+        assertThat(result.data().get(1).description()).isEqualTo("Desc2");
+
+        assertThat(result.metadata().pagination().totalPages()).isEqualTo(1L);
+        verify(sortParser).parseSorting(sorting);
+        verify(accountPersistencePort).findAll(eq(searchTerm), any(Pageable.class));
+    }
+
+    @Test
+    void deleteAccount_shouldDelete() {
+        UUID accId = UUID.randomUUID();
+
+        AccountModel model = new AccountModel();
+        model.setId(accId);
+        model.setDescription("To Delete");
+
+        when(accountPersistencePort.findById(accId)).thenReturn(Optional.of(model));
+
+        var response = accountServiceAdapter.deleteAccount(accId);
+
+        assertThat(response.data().id()).isEqualTo(accId);
+        assertThat(response.data().description()).isEqualTo("To Delete");
+        verify(accountPersistencePort).deleteAccount(model);
+    }
+
+    @Test
+    void updateAccountStatus_shouldSetNewStatus() {
+        UUID accId = UUID.randomUUID();
+        AccountModel model = new AccountModel();
+        model.setId(accId);
+        model.setStatus(AccountStatusEnum.PENDING);
+
+        when(accountPersistencePort.findById(accId)).thenReturn(Optional.of(model));
+
+        var result = accountServiceAdapter.updateAccountStatus(accId, "PAID");
+
+        assertThat(result.data().status()).isEqualTo(AccountStatusEnum.PAID);
+        verify(accountPersistencePort).saveAccount(model);
+    }
+
+    @Test
+    void getTotalPaid_shouldReturnValue() {
+        when(accountPersistencePort.calculateTotalPaid(any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(new BigDecimal("1234.56"));
+
+        var result = accountServiceAdapter.getTotalPaid("2023-01-01", "2023-02-01");
+
+        assertThat(result.data()).isEqualTo("1234.56");
+        verify(accountPersistencePort).calculateTotalPaid(eq(LocalDate.of(2023, 1, 1)), eq(LocalDate.of(2023, 2, 1)));
+    }
+
+    @Test
+    void importAccounts_shouldCallCsvImportPort() throws IOException {
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.getInputStream()).thenReturn(mock(InputStream.class));
+        when(accountCsvImportPort.importCsv(any(InputStream.class))).thenReturn(3);
+
+        var result = accountServiceAdapter.importAccounts(file);
+
+        assertThat(result.data()).isEqualTo(3);
+        verify(accountCsvImportPort).importCsv(any(InputStream.class));
+    }
+
+    public static Date localDateToDate(LocalDate localDate) {
+        return Date.from(
+                localDate.atStartOfDay(ZoneId.systemDefault()).toInstant()
+        );
+    }
+}

--- a/src/test/java/com/codesumn/accounts_payables_system_springboot/application/adapters/inbound/AuthServiceAdapterTest.java
+++ b/src/test/java/com/codesumn/accounts_payables_system_springboot/application/adapters/inbound/AuthServiceAdapterTest.java
@@ -1,0 +1,172 @@
+package com.codesumn.accounts_payables_system_springboot.application.adapters.inbound;
+
+import com.codesumn.accounts_payables_system_springboot.application.dtos.github.GitHubUserDto;
+import com.codesumn.accounts_payables_system_springboot.application.dtos.records.auth.AuthCredentialsRecordDto;
+import com.codesumn.accounts_payables_system_springboot.application.dtos.records.auth.AuthResponseDto;
+import com.codesumn.accounts_payables_system_springboot.application.dtos.records.github.GitHubTokenRequestRecordDto;
+import com.codesumn.accounts_payables_system_springboot.application.dtos.records.response.ResponseDto;
+import com.codesumn.accounts_payables_system_springboot.application.dtos.records.user.UserInputRecordDto;
+import com.codesumn.accounts_payables_system_springboot.domain.models.UserModel;
+import com.codesumn.accounts_payables_system_springboot.domain.outbound.*;
+import com.codesumn.accounts_payables_system_springboot.shared.enums.RolesEnum;
+import com.codesumn.accounts_payables_system_springboot.shared.exceptions.errors.CustomUserNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class AuthServiceAdapterTest {
+
+    @Mock
+    private UserPersistencePort userPersistencePort;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtServicePort jwtServicePort;
+
+    @Mock
+    private AuthenticationManager authenticationManager;
+
+    @Mock
+    private GitHubServicePort gitHubServicePort;
+
+    @InjectMocks
+    private AuthServiceAdapter authServiceAdapter;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void authenticateUser_shouldReturnAuthResponse_whenCredentialsAreValid() {
+        // Arrange
+        AuthCredentialsRecordDto credentials = new AuthCredentialsRecordDto("user@example.com", "password");
+        Authentication authentication = mock(Authentication.class);
+        UserDetails userDetails = mock(UserDetails.class);
+        UserModel userModel = new UserModel();
+        userModel.setEmail("user@example.com");
+
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+                .thenReturn(authentication);
+        when(authentication.getPrincipal()).thenReturn(userDetails);
+        when(userDetails.getUsername()).thenReturn("user@example.com");
+        when(userPersistencePort.findByEmail("user@example.com")).thenReturn(Optional.of(userModel));
+        when(jwtServicePort.generateToken("user@example.com")).thenReturn("jwt-token");
+
+        ResponseDto<AuthResponseDto> response = authServiceAdapter.authenticateUser(credentials);
+
+        assertThat(response.data().accessToken()).isEqualTo("jwt-token");
+        assertThat(response.data().user().email()).isEqualTo("user@example.com");
+        verify(authenticationManager).authenticate(any(UsernamePasswordAuthenticationToken.class));
+        verify(jwtServicePort).generateToken("user@example.com");
+    }
+
+    @Test
+    void authenticateUser_shouldThrowCustomUserNotFoundException_whenUserDoesNotExist() {
+        AuthCredentialsRecordDto credentials = new AuthCredentialsRecordDto("nonexistent@example.com", "password");
+        Authentication authentication = mock(Authentication.class);
+        UserDetails userDetails = mock(UserDetails.class);
+
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+                .thenReturn(authentication);
+        when(authentication.getPrincipal()).thenReturn(userDetails);
+        when(userDetails.getUsername()).thenReturn("nonexistent@example.com");
+        when(userPersistencePort.findByEmail("nonexistent@example.com")).thenReturn(Optional.empty());
+
+        assertThrows(CustomUserNotFoundException.class, () -> authServiceAdapter.authenticateUser(credentials));
+
+        verify(authenticationManager).authenticate(any(UsernamePasswordAuthenticationToken.class));
+        verify(userPersistencePort).findByEmail("nonexistent@example.com");
+    }
+
+    @Test
+    void authenticateGitHubUser_shouldAuthenticateAndReturnToken() {
+        GitHubTokenRequestRecordDto tokenRequest = new GitHubTokenRequestRecordDto("github-token");
+
+        GitHubUserDto gitHubUser = new GitHubUserDto();
+        gitHubUser.setName("John Doe");
+        gitHubUser.setEmail("john.doe@example.com");
+
+        UserModel savedUser = new UserModel();
+        savedUser.setId(UUID.randomUUID());
+        savedUser.setFirstName("John");
+        savedUser.setLastName("Doe");
+        savedUser.setEmail("john.doe@example.com");
+        savedUser.setPassword("encodedGithubToken");
+        savedUser.setRole(RolesEnum.USER);
+
+        when(gitHubServicePort.getGitHubUser("github-token")).thenReturn(gitHubUser);
+        when(userPersistencePort.existsByEmail("john.doe@example.com")).thenReturn(false);
+        when(passwordEncoder.encode("github-token")).thenReturn("encodedGithubToken");
+        doNothing().when(userPersistencePort).saveUser(any(UserModel.class));
+        when(jwtServicePort.generateToken("john.doe@example.com")).thenReturn("jwt-token");
+
+        ResponseDto<AuthResponseDto> response = authServiceAdapter.authenticateGitHubUser(tokenRequest);
+
+        assertThat(response.data().accessToken()).isEqualTo("jwt-token");
+        assertThat(response.data().user().email()).isEqualTo("john.doe@example.com");
+        verify(gitHubServicePort).getGitHubUser("github-token");
+        verify(userPersistencePort).existsByEmail("john.doe@example.com");
+        verify(passwordEncoder).encode("github-token");
+        verify(userPersistencePort).saveUser(any(UserModel.class));
+        verify(jwtServicePort).generateToken("john.doe@example.com");
+    }
+
+    @Test
+    void registerUser_shouldRegisterAndReturnToken() {
+
+        UserInputRecordDto userInput = new UserInputRecordDto(
+                "John",
+                "Doe",
+                "john.doe@example.com",
+                "password123",
+                "USER"
+        );
+
+        UserModel newUser = new UserModel();
+        newUser.setId(UUID.randomUUID());
+        newUser.setFirstName("John");
+        newUser.setLastName("Doe");
+        newUser.setEmail("john.doe@example.com");
+        newUser.setPassword("encodedPassword");
+        newUser.setRole(RolesEnum.USER);
+
+        UserDetails userDetails = mock(UserDetails.class);
+
+        when(userPersistencePort.findByEmail("john.doe@example.com")).thenReturn(Optional.empty());
+        when(passwordEncoder.encode("password123")).thenReturn("encodedPassword");
+
+        doNothing().when(userPersistencePort).saveUser(any(UserModel.class));
+
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+                .thenReturn(new UsernamePasswordAuthenticationToken(userDetails, "encodedPassword"));
+        when(userDetails.getUsername()).thenReturn("john.doe@example.com");
+        when(jwtServicePort.generateToken("john.doe@example.com")).thenReturn("jwt-token");
+
+        ResponseDto<AuthResponseDto> response = authServiceAdapter.registerUser(userInput);
+
+        assertThat(response.data().accessToken()).isEqualTo("jwt-token");
+        assertThat(response.data().user().email()).isEqualTo("john.doe@example.com");
+
+        verify(userPersistencePort).findByEmail("john.doe@example.com");
+        verify(passwordEncoder).encode("password123");
+        verify(userPersistencePort).saveUser(any(UserModel.class));
+        verify(authenticationManager).authenticate(any(UsernamePasswordAuthenticationToken.class));
+        verify(jwtServicePort).generateToken("john.doe@example.com");
+    }
+}

--- a/src/test/java/com/codesumn/accounts_payables_system_springboot/application/adapters/inbound/SpringBatchAccountCsvImportAdapterTest.java
+++ b/src/test/java/com/codesumn/accounts_payables_system_springboot/application/adapters/inbound/SpringBatchAccountCsvImportAdapterTest.java
@@ -1,0 +1,124 @@
+package com.codesumn.accounts_payables_system_springboot.application.adapters.inbound;
+
+import com.codesumn.accounts_payables_system_springboot.domain.models.AccountModel;
+import com.codesumn.accounts_payables_system_springboot.shared.exceptions.errors.CsvImportException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.item.file.FlatFileItemReader;
+import org.springframework.batch.item.file.transform.IncorrectTokenCountException;
+import org.springframework.core.io.InputStreamResource;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SpringBatchAccountCsvImportAdapterTest {
+
+
+    @Mock
+    private JobLauncher jobLauncher;
+
+    @Mock
+    private Job importAccountsJob;
+
+    @Mock
+    private FlatFileItemReader<AccountModel> reader;
+
+    private SpringBatchAccountCsvImportAdapter csvImportAdapter;
+
+    @BeforeEach
+    void setUp() {
+        csvImportAdapter = new SpringBatchAccountCsvImportAdapter(jobLauncher, importAccountsJob, reader);
+    }
+
+    @Test
+    void importCsv_shouldReturnImportedCount_whenJobIsSuccessful() throws Exception {
+
+        InputStream mockInputStream = new ByteArrayInputStream("mock CSV content".getBytes());
+        InputStreamResource resource = new InputStreamResource(mockInputStream);
+
+        JobExecution mockJobExecution = mock(JobExecution.class);
+        when(mockJobExecution.getStatus()).thenReturn(BatchStatus.COMPLETED);
+
+        ExecutionContext mockExecutionContext = new ExecutionContext();
+        mockExecutionContext.putInt("importedCount", 10);
+        when(mockJobExecution.getExecutionContext()).thenReturn(mockExecutionContext);
+
+        doNothing().when(reader).setResource(resource);
+
+        when(jobLauncher.run(any(Job.class), any(JobParameters.class))).thenReturn(mockJobExecution);
+
+        int importedCount = csvImportAdapter.importCsv(mockInputStream);
+
+        assertThat(importedCount).isEqualTo(10);
+    }
+
+    @Test
+    void importCsv_shouldThrowCsvImportException_whenJobFails() throws Exception {
+        InputStream mockInputStream = new ByteArrayInputStream("mock CSV content".getBytes());
+        InputStreamResource resource = new InputStreamResource(mockInputStream);
+
+        JobExecution mockJobExecution = mock(JobExecution.class);
+        when(mockJobExecution.getStatus()).thenReturn(BatchStatus.FAILED);
+        when(mockJobExecution.getAllFailureExceptions())
+                .thenReturn(List.of(new IllegalArgumentException("Invalid data")));
+
+        doNothing().when(reader).setResource(resource);
+
+        when(jobLauncher.run(any(Job.class), any(JobParameters.class))).thenReturn(mockJobExecution);
+
+        CsvImportException exception = assertThrows(
+                CsvImportException.class,
+                () -> csvImportAdapter.importCsv(mockInputStream)
+        );
+
+        assertThat(exception.getMessage()).contains("Invalid data");
+    }
+
+    @Test
+    void importCsv_shouldThrowCsvImportException_whenParseErrorOccurs() {
+        InputStream mockInputStream = new ByteArrayInputStream("mock CSV content".getBytes());
+        InputStreamResource resource = new InputStreamResource(mockInputStream);
+
+        IncorrectTokenCountException parseException = new IncorrectTokenCountException(5, 4);
+
+        doThrow(parseException).when(reader).setResource(resource);
+
+        CsvImportException exception = assertThrows(
+                CsvImportException.class,
+                () -> csvImportAdapter.importCsv(mockInputStream)
+        );
+
+        assertThat(exception.getMessage()).contains("CSV parse error");
+    }
+
+    @Test
+    void importCsv_shouldThrowRuntimeException_whenUnexpectedErrorOccurs() {
+        InputStream mockInputStream = new ByteArrayInputStream("mock CSV content".getBytes());
+        InputStreamResource resource = new InputStreamResource(mockInputStream);
+
+        doThrow(new RuntimeException("Unexpected error")).when(reader).setResource(resource);
+
+        RuntimeException exception = assertThrows(
+                RuntimeException.class,
+                () -> csvImportAdapter.importCsv(mockInputStream)
+        );
+
+        assertThat(exception.getMessage()).contains("Error importing CSV via Spring Batch");
+    }
+}

--- a/src/test/java/com/codesumn/accounts_payables_system_springboot/application/adapters/inbound/UserServiceAdapterTest.java
+++ b/src/test/java/com/codesumn/accounts_payables_system_springboot/application/adapters/inbound/UserServiceAdapterTest.java
@@ -1,0 +1,238 @@
+package com.codesumn.accounts_payables_system_springboot.application.adapters.inbound;
+
+import com.codesumn.accounts_payables_system_springboot.application.dtos.records.pagination.PaginationResponseDto;
+import com.codesumn.accounts_payables_system_springboot.application.dtos.records.response.ResponseDto;
+import com.codesumn.accounts_payables_system_springboot.application.dtos.records.user.UserInputRecordDto;
+import com.codesumn.accounts_payables_system_springboot.application.dtos.records.user.UserRecordDto;
+import com.codesumn.accounts_payables_system_springboot.domain.models.UserModel;
+import com.codesumn.accounts_payables_system_springboot.domain.outbound.UserPersistencePort;
+import com.codesumn.accounts_payables_system_springboot.shared.enums.RolesEnum;
+import com.codesumn.accounts_payables_system_springboot.shared.exceptions.errors.EmailAlreadyExistsException;
+import com.codesumn.accounts_payables_system_springboot.shared.exceptions.errors.ResourceNotFoundException;
+import com.codesumn.accounts_payables_system_springboot.shared.parsers.SortParser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.data.domain.*;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.io.IOException;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class UserServiceAdapterTest {
+
+    @Mock
+    private UserPersistencePort userPersistencePort;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private SortParser sortParser;
+
+    private UserServiceAdapter userServiceAdapter;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        userServiceAdapter = new UserServiceAdapter(
+                userPersistencePort,
+                passwordEncoder,
+                sortParser
+        );
+    }
+
+    @Test
+    void getUserById_shouldReturnUser_whenExists() {
+        UUID userId = UUID.randomUUID();
+        UserModel userModel = new UserModel();
+        userModel.setId(userId);
+        userModel.setFirstName("Jane");
+        userModel.setLastName("Doe");
+
+        when(userPersistencePort.findById(userId)).thenReturn(Optional.of(userModel));
+
+        ResponseDto<UserRecordDto> response = userServiceAdapter.getUserById(userId);
+
+        assertThat(response.data().id()).isEqualTo(userId);
+        assertThat(response.data().firstName()).isEqualTo("Jane");
+        verify(userPersistencePort).findById(userId);
+    }
+
+    @Test
+    void getUserById_shouldThrowResourceNotFound_whenNotFound() {
+        UUID userId = UUID.randomUUID();
+        when(userPersistencePort.findById(userId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userServiceAdapter.getUserById(userId))
+                .isInstanceOf(ResourceNotFoundException.class);
+
+        verify(userPersistencePort).findById(userId);
+    }
+
+    @Test
+    void createUser_shouldSaveAndReturnNewUser() {
+        UserInputRecordDto inputDto = new UserInputRecordDto(
+                "John",
+                "Doe",
+                "john.doe@example.com",
+                "secretPass",
+                "ADMIN"
+        );
+
+        when(userPersistencePort.findByEmail("john.doe@example.com"))
+                .thenReturn(Optional.empty());
+
+        when(passwordEncoder.encode("secretPass"))
+                .thenReturn("encodedSecretPass");
+
+        ResponseDto<UserRecordDto> response = userServiceAdapter.createUser(inputDto);
+
+        assertThat(response.data()).isNotNull();
+        assertThat(response.data().firstName()).isEqualTo("John");
+        assertThat(response.data().lastName()).isEqualTo("Doe");
+        assertThat(response.data().email()).isEqualTo("john.doe@example.com");
+        assertThat(response.data().role()).isEqualTo(RolesEnum.ADMIN);
+
+        verify(userPersistencePort).findByEmail("john.doe@example.com");
+        verify(passwordEncoder).encode("secretPass");
+        verify(userPersistencePort).saveUser(argThat(user ->
+                user.getFirstName().equals("John") &&
+                        user.getLastName().equals("Doe") &&
+                        user.getEmail().equals("john.doe@example.com") &&
+                        user.getPassword().equals("encodedSecretPass") &&
+                        user.getRole() == RolesEnum.ADMIN
+        ));
+    }
+
+    @Test
+    void createUser_shouldThrowEmailAlreadyExists_whenEmailDuplicate() {
+        UserInputRecordDto inputDto = new UserInputRecordDto(
+                "Mary",
+                "Doe",
+                "mary@example.com",
+                "secret",
+                "USER"
+        );
+
+        UserModel existingUser = new UserModel();
+        existingUser.setId(UUID.randomUUID());
+        existingUser.setEmail("mary@example.com");
+
+        when(userPersistencePort.findByEmail("mary@example.com"))
+                .thenReturn(Optional.of(existingUser));
+
+        assertThatThrownBy(() -> userServiceAdapter.createUser(inputDto))
+                .isInstanceOf(EmailAlreadyExistsException.class);
+
+        verify(userPersistencePort).findByEmail("mary@example.com");
+        verifyNoMoreInteractions(userPersistencePort);
+    }
+
+    @Test
+    void updateUser_shouldUpdateAndReturnUser() {
+        UUID userId = UUID.randomUUID();
+
+        UserModel existingUser = new UserModel();
+        existingUser.setId(userId);
+        existingUser.setFirstName("OldFirst");
+        existingUser.setLastName("OldLast");
+        existingUser.setEmail("oldmail@example.com");
+        existingUser.setPassword("oldPass");
+        existingUser.setRole(RolesEnum.USER);
+
+        when(userPersistencePort.findById(userId))
+                .thenReturn(Optional.of(existingUser));
+
+        when(userPersistencePort.findByEmail("newmail@example.com"))
+                .thenReturn(Optional.empty());
+
+        when(passwordEncoder.encode("newPass"))
+                .thenReturn("encodedNewPass");
+
+        UserInputRecordDto dto = new UserInputRecordDto(
+                "NewFirst",
+                "NewLast",
+                "newmail@example.com",
+                "newPass",
+                "ADMIN"
+        );
+
+        var response = userServiceAdapter.updateUser(userId, dto);
+
+        assertThat(response.data().id()).isEqualTo(userId);
+        assertThat(response.data().firstName()).isEqualTo("NewFirst");
+        assertThat(response.data().lastName()).isEqualTo("NewLast");
+        assertThat(response.data().email()).isEqualTo("newmail@example.com");
+        assertThat(response.data().role()).isEqualTo(RolesEnum.ADMIN);
+
+
+        verify(userPersistencePort).findById(userId);
+        verify(userPersistencePort).findByEmail("newmail@example.com");
+        verify(passwordEncoder).encode("newPass");
+
+        verify(userPersistencePort).saveUser(argThat(user ->
+                user.getId().equals(userId) &&
+                        user.getFirstName().equals("NewFirst") &&
+                        user.getLastName().equals("NewLast") &&
+                        user.getEmail().equals("newmail@example.com") &&
+                        user.getPassword().equals("encodedNewPass") &&
+                        user.getRole() == RolesEnum.ADMIN
+        ));
+    }
+
+    @Test
+    void deleteUser_shouldRemoveUserAndReturnDeletedInfo() {
+        UUID userId = UUID.randomUUID();
+        UserModel existingUser = new UserModel();
+        existingUser.setId(userId);
+        existingUser.setFirstName("ToDelete");
+
+        when(userPersistencePort.findById(userId))
+                .thenReturn(Optional.of(existingUser));
+
+        var response = userServiceAdapter.deleteUser(userId);
+
+        assertThat(response.data().id()).isEqualTo(userId);
+        assertThat(response.data().firstName()).isEqualTo("ToDelete");
+        verify(userPersistencePort).deleteUser(existingUser);
+    }
+
+    @Test
+    void getAll_shouldReturnPagination() throws IOException {
+        int page = 1;
+        int pageSize = 5;
+        String searchTerm = "someTerm";
+        String sorting = "sortingJSON";
+
+        when(sortParser.parseSorting(sorting)).thenReturn(Sort.by("firstName"));
+
+        UserModel u1 = new UserModel();
+        u1.setId(UUID.randomUUID());
+        u1.setFirstName("Alice");
+
+        UserModel u2 = new UserModel();
+        u2.setId(UUID.randomUUID());
+        u2.setFirstName("Bob");
+
+        Page<UserModel> userPage = new PageImpl<>(
+                List.of(u1, u2),
+                PageRequest.of(0, pageSize, Sort.by("firstName")),
+                2
+        );
+
+        when(userPersistencePort.findAll(eq(searchTerm), any(Pageable.class)))
+                .thenReturn(userPage);
+
+        PaginationResponseDto<List<UserRecordDto>> result =
+                userServiceAdapter.getAll(page, pageSize, searchTerm, sorting);
+
+        assertThat(result.data()).hasSize(2);
+        assertThat(result.data().getFirst().firstName()).isEqualTo("Alice");
+        verify(sortParser).parseSorting(sorting);
+        verify(userPersistencePort).findAll(eq(searchTerm), any(Pageable.class));
+    }
+}

--- a/src/test/java/com/codesumn/accounts_payables_system_springboot/application/mappers/UserMapperTest.java
+++ b/src/test/java/com/codesumn/accounts_payables_system_springboot/application/mappers/UserMapperTest.java
@@ -1,0 +1,32 @@
+package com.codesumn.accounts_payables_system_springboot.application.mappers;
+
+import com.codesumn.accounts_payables_system_springboot.application.dtos.records.user.UserInputRecordDto;
+import com.codesumn.accounts_payables_system_springboot.domain.models.UserModel;
+import com.codesumn.accounts_payables_system_springboot.shared.enums.RolesEnum;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserMapperTest {
+
+    @Test
+    void fromDto_shouldMapDtoToUserModel() {
+
+        UserInputRecordDto dto = new UserInputRecordDto(
+                "John",
+                "Doe",
+                "john.doe@example.com",
+                "password123",
+                "USER"
+        );
+
+        UserModel user = UserMapper.fromDto(dto);
+
+        assertThat(user).isNotNull();
+        assertThat(user.getFirstName()).isEqualTo("John");
+        assertThat(user.getLastName()).isEqualTo("Doe");
+        assertThat(user.getEmail()).isEqualTo("john.doe@example.com");
+        assertThat(user.getPassword()).isEqualTo("password123");
+        assertThat(user.getRole()).isEqualTo(RolesEnum.USER);
+    }
+}

--- a/src/test/java/com/codesumn/accounts_payables_system_springboot/application/services/CustomUserDetailsServiceTest.java
+++ b/src/test/java/com/codesumn/accounts_payables_system_springboot/application/services/CustomUserDetailsServiceTest.java
@@ -1,0 +1,62 @@
+package com.codesumn.accounts_payables_system_springboot.application.services;
+
+import com.codesumn.accounts_payables_system_springboot.domain.models.UserModel;
+import com.codesumn.accounts_payables_system_springboot.domain.outbound.UserPersistencePort;
+import com.codesumn.accounts_payables_system_springboot.shared.enums.RolesEnum;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+class CustomUserDetailsServiceTest {
+
+    @Mock
+    private UserPersistencePort userPersistencePort;
+
+    @InjectMocks
+    private CustomUserDetailsService customUserDetailsService;
+
+    CustomUserDetailsServiceTest() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void loadUserByUsername_shouldReturnUserDetails_whenUserExists() {
+
+        String email = "john.doe@example.com";
+        UserModel user = new UserModel();
+        user.setEmail(email);
+        user.setPassword("encodedPassword");
+        user.setRole(RolesEnum.USER);
+
+        when(userPersistencePort.findByEmail(email)).thenReturn(Optional.of(user));
+
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername(email);
+
+        assertThat(userDetails).isNotNull();
+        assertThat(userDetails.getUsername()).isEqualTo(email);
+        assertThat(userDetails.getPassword()).isEqualTo("encodedPassword");
+        assertThat(userDetails.getAuthorities()).hasSize(1);
+        assertThat(userDetails.getAuthorities().iterator().next().getAuthority()).isEqualTo(RolesEnum.USER.name());
+    }
+
+    @Test
+    void loadUserByUsername_shouldThrowUsernameNotFoundException_whenUserDoesNotExist() {
+
+        String email = "nonexistent@example.com";
+
+        when(userPersistencePort.findByEmail(email)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> customUserDetailsService.loadUserByUsername(email))
+                .isInstanceOf(UsernameNotFoundException.class)
+                .hasMessage("User not found");
+    }
+}


### PR DESCRIPTION
- Introduce `AccountItemWriterTest` to validate the persistence and step lifecycle logic of account item writing.
- Create `UserServiceAdapterTest` to ensure proper behavior of core user service features including CRUD operations and pagination.
- Add `UserMapperTest` to validate the mapping logic between user DTOs and domain models.
- Implement `AuthServiceAdapterTest` to verify authentication workflows including JWT-based login, GitHub OAuth, and registration.
- Add `SpringBatchAccountCsvImportAdapterTest` to cover account CSV import handling, including edge cases like parsing errors.
- Introduce `CustomUserDetailsServiceTest` for validating the UserDetails loading mechanism with both success and failure scenarios.
- Add `AccountServiceAdapterTest` to ensure correct functionality of account service with focus on query and exception handling.